### PR TITLE
Add `Array` to list of constructors to `JSON.stringify`

### DIFF
--- a/src/Pux/Devtool.js
+++ b/src/Pux/Devtool.js
@@ -17,7 +17,7 @@ exports.actionToString = function (a) {
 
 exports.stateToString = function (s) {
   return JSON.stringify(s, function (key, val) {
-    if (!val.constructor.name.match(/(Object|String|Number|Date|Symbol)/)) {
+    if (!val.constructor.name.match(/(Object|Array|String|Number|Date|Symbol)/)) {
       return exports.actionToString(val);
     }
     return val;


### PR DESCRIPTION
Fixes #1

This seemed like a pretty quick change so I gave it a shot.  The only thing I was wondering is if there should be a way to override this, or if it should try to discover `show` instances for the given type (that might get crazy..).  I saw someone mention `purescript-reflection` the other day, which might help with that.  ¯_(ツ)_/¯  That'd probably be a new issue though.
