### PR TITLE
Set a large z-index for the devtool

### DIFF
--- a/src/Pux/Devtool.purs
+++ b/src/Pux/Devtool.purs
@@ -106,6 +106,10 @@ view appView state =
   div
     []
     [ Pux.Html.style [] [ text $ """
+        .pux-devtool {
+          z-index: 16777271;
+        }
+        
         .pux-devtool-container {
           font-family: sans-serif;
           font-size: 14px;


### PR DESCRIPTION
I'm working with some react-bootstrap components that cover the devtool.  Setting z-index should keep the devtool on top most of the time.
