### PR TITLE
Update deps to latest. Use PSC 0.10.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/alexmingoia/pux-devtool",
   "moduleType": [],
   "dependencies": {
-    "purescript-pux": "^5.0.1",
-    "purescript-pux-css": "^2.0.0"
+    "purescript-pux": "https://github.com/chexxor/purescript-pux.git#6d1d846c5ab65a1e845437df2bffcb9038cc24cc",
+    "purescript-pux-css": "https://github.com/chexxor/pux-css.git#1bfed991e9e8c6e604b7d2d6d6b384ec20fc2ebe"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   },
   "homepage": "https://github.com/alexmingoia/pux-devtool#readme",
   "devDependencies": {
-    "purescript": "^0.9.1"
+    "purescript": "^0.10.1"
   }
 }


### PR DESCRIPTION
I've got a PR to update purescript-pux's deps: https://github.com/alexmingoia/purescript-pux/pull/79
I've got a PR to update purescript-css's deps: https://github.com/slamdata/purescript-css/pull/43

Right now, this PR references those PRed branches of mine. We can wait to merge this until those PRs are merged, then I'll update this PR to use the latest version of those repos.

`pulp build` gives no errors.