### PR TITLE
Add options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components/
 node_modules/
 npm-debug.log
 output/
+.psc-ide-port

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Replace `Pux.start` with `Pux.Devtool.start` and that's it!
+Replace `Pux.start` with `Pux.Devtool.start`, add `Pux.Devtool.Options` and that's it!
 
 ```purescript
 main = do
@@ -17,6 +17,9 @@ main = do
     , view: view
     , inputs: []
     }
+    Pux.Devtool.defaultOptions
+    -- or replace `Pux.Devtool.defaultOptions` with custom `Options`, e.g.
+    -- { opened: false }
 
   renderToDOM "#app" app.html
 ```

--- a/src/Pux/Devtool.purs
+++ b/src/Pux/Devtool.purs
@@ -6,13 +6,14 @@ import Data.Tuple (Tuple(Tuple))
 import Control.Monad.Eff (Eff)
 import Pux (App, Config, CoreEffects, EffModel, noEffects)
 import Pux (start) as Pux
-import Pux.CSS hiding (App(..), style, div, button, span, map, h1)
+import Pux.CSS hiding (App(..), div, button, span, map, h1)
 import Pux.CSS (style) as PuxCSS
 import Pux.Html (button, div, h1, Html, span, text, svg, path)
-import Pux.Html (style) as Pux.Html
-import Pux.Html.Attributes (className, d, viewBox, style, dangerouslySetInnerHTML)
+import Pux.Html (style) as PuxHtml
+import Pux.Html.Attributes (className, d, viewBox, dangerouslySetInnerHTML)
+import Pux.Html.Attributes (style) as PuxAttr
 import Pux.Html.Events (onClick)
-import Prelude ((#), (<), (>), (<>), (+), (-), ($), const, map, negate, not, bind, pure, show)
+import Prelude ((#), (<), (>), (<<<), (<>), (+), (-), ($), const, map, negate, not, bind, pure, show)
 
 data Action a
   = AppAction a
@@ -105,7 +106,7 @@ view :: forall s a. (s -> Html a) -> State s -> Html (Action a)
 view appView state =
   div
     []
-    [ Pux.Html.style [] [ text $ """
+    [ PuxHtml.style [] [ text $ """
         .pux-devtool {
           z-index: 16777271;
         }
@@ -248,7 +249,7 @@ view appView state =
                         ]
                     ]
                 ]
-            , div [ style
+            , div [ PuxAttr.style
                       [ Tuple "marginTop" "1em", Tuple "fontWeight" "bold" ]
                   ]
                   [ text (selectedAction state) ]
@@ -263,18 +264,22 @@ view appView state =
         , div
             [ className "toggle-hide"
             , onClick (const ToggleOpen)
-            , style $ [ Tuple "lineHeight" "30px"
+            , PuxAttr.style $ [ Tuple "lineHeight" "30px"
                     , Tuple "cursor" "pointer"
                     , Tuple "textAlign" "center"
                     , Tuple "verticalAlign" "middle"
                     ] <> css do
                 position absolute
                 backgroundColor (rgb 66 66 84)
-                borderRadius (3.0# px) (0.0# px) (0.0#px) (3.0# px)
+                case state.opened of
+                  true -> borderRadius (3.0# px) (0.0# px) (0.0#px) (3.0# px)
+                  _ -> borderRadius (0.0# px) (3.0# px) (3.0#px) (0.0# px)
                 top (50.0# pct)
                 left (-12.0# px)
                 height (30.0# px)
                 width (12.0# px)
+                let dValue = if state.opened then 0.0 else 180.0
+                transform <<< rotate $ dValue # deg
             ]
             [ span
                 [ className "pux-devtool-icon caret-right" ]

--- a/src/Pux/Devtool.purs
+++ b/src/Pux/Devtool.purs
@@ -6,9 +6,9 @@ import Data.Tuple (Tuple(Tuple))
 import Control.Monad.Eff (Eff)
 import Pux (App, Config, CoreEffects, EffModel, noEffects)
 import Pux (start) as Pux
-import Pux.CSS hiding (style)
-import Pux.CSS (style) as Pux.CSS
-import Pux.Html (button, div, h1, Html, i, span, text, svg, path)
+import Pux.CSS hiding (App(..), style, div, button, span, map, h1)
+import Pux.CSS (style) as PuxCSS
+import Pux.Html (button, div, h1, Html, span, text, svg, path)
 import Pux.Html (style) as Pux.Html
 import Pux.Html.Attributes (className, d, viewBox, style, dangerouslySetInnerHTML)
 import Pux.Html.Events (onClick)
@@ -109,7 +109,7 @@ view appView state =
         .pux-devtool {
           z-index: 16777271;
         }
-        
+
         .pux-devtool-container {
           font-family: sans-serif;
           font-size: 14px;
@@ -169,7 +169,7 @@ view appView state =
     """ ]
     , div
         [ className "pux-devtool"
-        , Pux.CSS.style do
+        , PuxCSS.style do
             position fixed
             right (0.0# px)
             width $ px
@@ -183,7 +183,7 @@ view appView state =
         [ div
             [ className "pux-devtool-container" ]
             [ h1
-                [ Pux.CSS.style do
+                [ PuxCSS.style do
                     fontSize (1.2# em)
                     marginTop (0.0# px)
                     fontWeight (weight 400.0)
@@ -253,7 +253,7 @@ view appView state =
                   ]
                   [ text (selectedAction state) ]
             , div
-                [ Pux.CSS.style do
+                [ PuxCSS.style do
                     fontSize (0.8# em)
                     marginTop (1.0# em)
                 , dangerouslySetInnerHTML (stateToString (selectedState state))
@@ -286,7 +286,7 @@ view appView state =
         ]
     , div
         [ className "pux-devtool-app-container"
-        , Pux.CSS.style do
+        , PuxCSS.style do
             marginRight $ px
               if state.opened then state.width else 0.0
         ]

--- a/src/Pux/Devtool.purs
+++ b/src/Pux/Devtool.purs
@@ -34,14 +34,23 @@ type State s =
   , width :: Number
   }
 
-init :: forall s. s -> State s
-init s =
+type Options = {
+  opened :: Boolean
+}
+
+defaultOptions :: Options
+defaultOptions = {
+  opened: true
+}
+
+init :: forall s. s -> Options -> State s
+init s o = do
   { actions: singleton "App initialized. Awaiting action..."
   , states: singleton s
   , init: s
   , length: 1
   , index: 0
-  , opened: true
+  , opened: o.opened
   , width: 360.0
   }
 
@@ -55,10 +64,10 @@ foreign import actionToString :: forall a. a -> String
 
 foreign import stateToString :: forall s. s -> String
 
-start :: forall a s e. (Config s a e) -> Eff (CoreEffects e) (App s (Action a))
-start config = do
+start :: forall a s e. (Config s a e) -> Options -> Eff (CoreEffects e) (App s (Action a))
+start config options = do
   app <- Pux.start
-    { initialState: init config.initialState
+    { initialState: init config.initialState options
     , update: update config.update
     , view: view config.view
     , inputs: map (map AppAction) config.inputs


### PR DESCRIPTION
Provide `Options` to `pux-devtool` (e.g. start with an opened or closed panel via `opened`)

Example of custom `Options`:

```purescript
debug :: State -> Eff (CoreEffects AppEffects) (App State (Pux.Devtool.Action Action))
debug state = do
  appConfig <- config state
  app <- Pux.Devtool.start appConfig {opened: false}
  renderToDOM "#app" app.html
  pure app
```

Example of `defaultOptions`:

```purescript
debug :: State -> Eff (CoreEffects AppEffects) (App State (Pux.Devtool.Action Action))
debug state = do
  appConfig <- config state
  app <- Pux.Devtool.start appConfig Pux.Devtool.defaultOptions
  renderToDOM "#app" app.html
  pure app
```

P.S. Pull request includes some fixes to avoid ~30 warnings of `psc`. And as a tiny extra special an opened icon which is rotated depending on open status lol